### PR TITLE
Add ability to mute and unmute hosts in DataDog 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 *.swp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ to:"<time description>"
 
 Time descriptions are parsed by https://github.com/mojombo/chronic
 
+### Muting
+
+Muting a host:
+
+```
+Lita dd mute <hostname> [message:"Some reason"]
+```
+
+Unmuting a host:
+
+```
+Lita dd unmute <hostname>
+```
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/lib/lita/handlers/datadog.rb
+++ b/lib/lita/handlers/datadog.rb
@@ -18,9 +18,48 @@ module Lita
         }
       )
 
+      route(
+        /^dd\smute\s(?<hostname>\S*)(\smessage:"(?<message>.*)")?$/,
+        :mute,
+        command: true,
+        help: {
+          t('help.mute.syntax') => t('help.mute.desc')
+        }
+      )
+
+      route(
+        /^dd\sunmute\s(?<hostname>\S*)$/,
+        :unmute,
+        command: true,
+        help: {
+          t('help.unmute.syntax') => t('help.unmute.desc')
+        }
+      )
+
       def graph(response)
         content = snapshot(parse_arguments(response.match_data['args']))
         response.reply(content)
+      end
+
+      def mute(response)
+        hostname = response.match_data['hostname']
+        message = response.match_data['message']
+        args = {}
+        args['message'] = message unless message.nil?
+        if mute_host(hostname, args)
+          response.reply(t('mute.success', host: hostname))
+        else
+          response.reply(t('errors.request'))
+        end
+      end
+
+      def unmute(response)
+        hostname = response.match_data['hostname']
+        if unmute_host(hostname)
+          response.reply(t('unmute.success', host: hostname))
+        else
+          response.reply(t('errors.request'))
+        end
       end
     end
 

--- a/lib/lita/helpers/utilities.rb
+++ b/lib/lita/helpers/utilities.rb
@@ -2,6 +2,34 @@ module Lita
   module Helpers
     # Helpers to go alongside fetching & parsing things
     module Utilities
+      def mute_host(hostname, args)
+        client = Dogapi::Client.new(config.api_key, config.application_key)
+        return false unless client
+
+        return_code, contents = client.mute_host(hostname, args)
+
+        if return_code.to_s != '200'
+          log.warning("URL (#{return_code}): #{contents['errors'].join('\n')}")
+          return false
+        end
+
+        true
+      end
+
+      def unmute_host(hostname)
+        client = Dogapi::Client.new(config.api_key, config.application_key)
+        return false unless client
+
+        return_code, contents = client.unmute_host(hostname)
+
+        if return_code.to_s != '200'
+          log.warning("URL (#{return_code}): #{contents['errors'].join('\n')}")
+          return false
+        end
+
+        true
+      end
+
       def get_graph_url(metric_query, start_ts, end_ts, event_query)
         client = Dogapi::Client.new(config.api_key, config.application_key)
 

--- a/lita-datadog.gemspec
+++ b/lita-datadog.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-datadog'
-  spec.version       = '0.9.0'
+  spec.version       = '0.10.0'
   spec.authors       = ['Eric Sigler']
   spec.email         = ['me@esigler.com']
   spec.description   = 'A Datadog plugin for Lita'
-  spec.summary       = 'A Datadog plugin for Lita'
+  spec.summary       = spec.description
   spec.homepage      = 'http://github.com/esigler/lita-datadog'
   spec.license       = 'MIT'
   spec.metadata      = { 'lita_plugin_type' => 'handler' }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,8 +3,18 @@ en:
     handlers:
       datadog:
         errors:
-          request: Error requesting Datadog graph
+          request: Error making DataDog request
         help:
           graph:
             syntax: 'graph metric:"simple.metric.1{*},simple.metric.5{*}'
             desc: 'Graph those metrics, for the default time range'
+          mute:
+            syntax: 'dd mute <hostname> [message:"Some reason"]'
+            desc: 'Mute a host in DataDog, optionally with a message'
+          unmute:
+            syntax: 'dd unmute <hostname>'
+            desc: 'Unmute a host in DataDog'
+        mute:
+          success: "Host %{host} muted"
+        unmute:
+          success: "Host %{host} unmuted"

--- a/spec/lita/handlers/datadog_spec.rb
+++ b/spec/lita/handlers/datadog_spec.rb
@@ -33,24 +33,6 @@ describe Lita::Handlers::Datadog, lita_handler: true do
       .to(:graph)
   end
 
-  describe '.default_config' do
-    it 'sets the api_key to nil' do
-      expect(Lita.config.handlers.datadog.api_key).to be_nil
-    end
-
-    it 'sets the application_key to nil' do
-      expect(Lita.config.handlers.datadog.application_key).to be_nil
-    end
-
-    it 'sets the timerange to 3600' do
-      expect(Lita.config.handlers.datadog.timerange).to eq(3600)
-    end
-
-    it 'sets the waittime to 0' do
-      expect(Lita.config.handlers.datadog.waittime).to eq(0)
-    end
-  end
-
   describe '#graph' do
     it 'with valid metric returns an image url' do
       expect(Dogapi::Client).to receive(:new) { success }

--- a/spec/lita/handlers/datadog_spec.rb
+++ b/spec/lita/handlers/datadog_spec.rb
@@ -2,12 +2,18 @@ require 'spec_helper'
 
 describe Lita::Handlers::Datadog, lita_handler: true do
   EXAMPLE_IMAGE_URL = 'http://www.example.com/path/that/ends/in.png'.freeze
-  EXAMPLE_ERROR_MSG = 'Error requesting Datadog graph'.freeze
+  EXAMPLE_ERROR_MSG = 'Error making DataDog request'.freeze
 
   let(:success) do
     client = double
     allow(client).to receive(:graph_snapshot) {
       [200, { 'snapshot_url' => EXAMPLE_IMAGE_URL }]
+    }
+    allow(client).to receive(:mute_host) {
+      [200, { 'hostname' => 'host01' }]
+    }
+    allow(client).to receive(:unmute_host) {
+      [200, { 'hostname' => 'host01' }]
     }
     client
   end
@@ -15,6 +21,8 @@ describe Lita::Handlers::Datadog, lita_handler: true do
   let(:error) do
     client = double
     allow(client).to receive(:graph_snapshot) { [500, { 'errors' => ['foo'] }] }
+    allow(client).to receive(:mute_host) { [500, { 'errors' => ['foo'] }] }
+    allow(client).to receive(:unmute_host) { [500, { 'errors' => ['foo'] }] }
     client
   end
 
@@ -31,6 +39,10 @@ describe Lita::Handlers::Datadog, lita_handler: true do
     is_expected.to route_command(
       'graph metric:"system.load.1{*}" event:"sources:something"')
       .to(:graph)
+
+    is_expected.to route_command('dd mute host01').to(:mute)
+    is_expected.to route_command('dd mute host01 message:"Foo Bar"').to(:mute)
+    is_expected.to route_command('dd unmute host01')
   end
 
   describe '#graph' do
@@ -61,6 +73,40 @@ describe Lita::Handlers::Datadog, lita_handler: true do
     it 'with an invalid event returns an error' do
       expect(Dogapi::Client).to receive(:new) { error }
       send_command('graph metric:"system.load.1{*}" event:"omg:wtf"')
+      expect(replies.last).to eq(EXAMPLE_ERROR_MSG)
+    end
+  end
+
+  describe '#mute' do
+    it 'mutes a hostname' do
+      expect(Dogapi::Client).to receive(:new) { success }
+      send_command('dd mute host01')
+      expect(replies.last).to eq('Host host01 muted')
+    end
+
+    it 'mutes a hostname with a message' do
+      expect(Dogapi::Client).to receive(:new) { success }
+      send_command('dd mute host01 message:"Foo Bar"')
+      expect(replies.last).to eq('Host host01 muted')
+    end
+
+    it 'reports an error if there was a problem with the request' do
+      expect(Dogapi::Client).to receive(:new) { error }
+      send_command('dd mute host01')
+      expect(replies.last).to eq(EXAMPLE_ERROR_MSG)
+    end
+  end
+
+  describe '#unmute' do
+    it 'unmutes a hostname' do
+      expect(Dogapi::Client).to receive(:new) { success }
+      send_command('dd unmute host01')
+      expect(replies.last).to eq('Host host01 unmuted')
+    end
+
+    it 'reports an error if there was a problem with the request' do
+      expect(Dogapi::Client).to receive(:new) { error }
+      send_command('dd unmute host01')
       expect(replies.last).to eq(EXAMPLE_ERROR_MSG)
     end
   end


### PR DESCRIPTION
Here's a quick piece of helpful functionality - adding the ability to mute and unmute a host.

Also removed a redundant test.

Fixes #5.
